### PR TITLE
Fix material theme bright black

### DIFF
--- a/themes/material_theme.yaml
+++ b/themes/material_theme.yaml
@@ -18,7 +18,7 @@ colors:
 
   # Bright colors
   bright:
-    black:   '0xff262b'
+    black:   '0xa1a1a1'
     red:     '0xeb606b'
     green:   '0xc3e88d'
     yellow:  '0xf7eb95'


### PR DESCRIPTION
The value `0xff262b` is in fact red so I've added a bright(ish) black to fix it.